### PR TITLE
Pack hyphenation table in ZIP and publish to Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+spell-no
+========
+
+## Maven setup
+
+Add to `~/.m2/settings.xml` (replace USERNAME and TOKEN with your Github username and token):
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <activeProfiles>
+    <activeProfile>github-spell-no</activeProfile>
+  </activeProfiles>
+
+  <profiles>
+    <profile>
+      <id>github-spell-no</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+          <id>github-spell-no</id>
+          <url>https://maven.pkg.github.com/nlbdev/spell-no</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <servers>
+    <server>
+      <id>github-spell-no</id>
+      <username>USERNAME</username>
+      <password>TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+See also:
+
+- [GitHub Packages: Working with the Apache Maven registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry)
+
+
+## Build and publish
+
+```bash
+cd norsk/patterns
+make publish
+```
+

--- a/norsk/patterns/.gitignore
+++ b/norsk/patterns/.gitignore
@@ -1,5 +1,6 @@
 /feil.pat*
 /hyph_no_NO.dic
+/hyph_no_NO.zip
 /hyphlist1.txt.gz
 /hyphlist2.txt.gz
 /hyphlist3.txt.gz

--- a/norsk/patterns/Makefile
+++ b/norsk/patterns/Makefile
@@ -941,7 +941,8 @@ lightclean:
 	rm -f hyphlist[124].patinput
 
 clean :
-	rm -f hyph_no_NO.dic                  \
+	rm -f hyph_no_NO.zip                  \
+	      hyph_no_NO.dic                  \
 	      hyphlist{1,2,3,4}.txt.gz        \
 	      no.tra                          \
 	      no.tra1                         \
@@ -1055,3 +1056,25 @@ patw9.txt: patw8.txt hyphenologist.verygood no.tra1
 # Create patterns file for OpenOffice.org (Libhyphen)
 hyph_no_NO.dic: pat49.txt
 	LC_CTYPE=UTF-8 perl substrings.pl $< $@ ISO8859-1 2 2
+
+hyph_no_NO.zip : hyph_no_NO.dic
+	zip $@ $^
+
+.PHONY : zip
+zip : hyph_no_NO.zip
+
+VERSION := 1.0.0
+
+# Publish ZIP in Maven repo
+.PHONY : publish
+publish : hyph_no_NO.zip
+	mvn org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy-file \
+		-Durl=https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/ \
+		-DrepositoryId=sonatype-nexus-staging \
+		-Dfile=$< \
+		-DgroupId=no.nlb \
+		-DartifactId=spell-no-patterns \
+		-Dversion=$(VERSION) \
+		-Dpackaging=zip \
+		-DgeneratePom=true \
+		-DgeneratePom.description="Norwegian hyphenation dictionary"

--- a/norsk/patterns/Makefile
+++ b/norsk/patterns/Makefile
@@ -1069,8 +1069,8 @@ VERSION := 1.0.0
 .PHONY : publish
 publish : hyph_no_NO.zip
 	mvn org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M2:deploy-file \
-		-Durl=https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/ \
-		-DrepositoryId=sonatype-nexus-staging \
+		-Durl=https://maven.pkg.github.com/nlbdev/spell-no \
+		-DrepositoryId=github-spell-no \
 		-Dfile=$< \
 		-DgroupId=no.nlb \
 		-DartifactId=spell-no-patterns \


### PR DESCRIPTION
`make publish` will build the hyphenation table, pack it in a ZIP, and publish it to a Maven repository. I've chosen groupId "no.nlb" and artifactId "spell-no-patterns", but this can of course be changed. I've tested with Sonatype, but it should also be possible to use Github Packages.